### PR TITLE
feat(CHIST-5791): add targetName feature

### DIFF
--- a/api/v1alpha1/copyresource_types.go
+++ b/api/v1alpha1/copyresource_types.go
@@ -37,6 +37,10 @@ type CopyResourceSpec struct {
 	// The TargetNamespace the Resource should be copied to
 	// +kubebuilder:validation:Required
 	TargetNamespace string `json:"targetNamespace"`
+
+	// The TargetName the Resource should be named in TargetNamespace
+	// +kubebuilder:validation:Optional
+	TargetName string `json:"targetName"`
 }
 
 // CopyResourceStatus defines the observed state of CopyResource

--- a/config/crd/bases/resource.baloise.ch_copyresources.yaml
+++ b/config/crd/bases/resource.baloise.ch_copyresources.yaml
@@ -45,6 +45,9 @@ spec:
             metaName:
               description: The MetaName of the Resource found in metadata.name
               type: string
+            targetName:
+              description: The TargetName the Resource should be named in TargetNamespace
+              type: string
             targetNamespace:
               description: The TargetNamespace the Resource should be copied to
               type: string

--- a/controllers/copyresource_controller.go
+++ b/controllers/copyresource_controller.go
@@ -92,7 +92,11 @@ func (r *CopyResourceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	targetResource.SetResourceVersion("")
 	targetResource.SetUID("")
 	targetResource.SetNamespace(copyResource.Spec.TargetNamespace)
-	targetResource.SetName(copyResource.Namespace + "-" + copyResource.Name)
+	if copyResource.Spec.TargetName != "" {
+		targetResource.SetName(copyResource.Spec.TargetName)
+	} else {
+		targetResource.SetName(copyResource.Namespace + "-" + copyResource.Name)
+	}
 	targetResource.SetOwnerReferences([]metav1.OwnerReference{buildOwnerReferenceToCopyResource(copyResource)})
 
 	exists := isObjectExists(r, targetResource, log)


### PR DESCRIPTION
this feature will enable you to define the name (targetName) of the
copied resource at the targetNamespace